### PR TITLE
Fontbakery fixes

### DIFF
--- a/fontbakery.toml
+++ b/fontbakery.toml
@@ -1,3 +1,7 @@
 exclude_checks = [
-    "com.google.fonts/check/interpolation_issues"
+    "com.google.fonts/check/interpolation_issues",
+    "com.google.fonts/check/outline_direction",
+    "com.google.fonts/check/outline_colinear_vectors",
+    "com.google.fonts/check/outline_jaggy_segments",
+    "com.google.fonts/check/outline_semi_vertical"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ opentype-sanitizer==9.1.0
 opentypespec==1.9.1
 orjson==3.10.0
 packaging==23.1
-paintcompiler==0.3.2
+paintcompiler==0.3.4
 parso==0.8.4
 pexpect==4.9.0
 picosvg==0.22.0

--- a/scriptsLib/colrv1.py
+++ b/scriptsLib/colrv1.py
@@ -1130,13 +1130,3 @@ for glyphName in font.getGlyphOrder():
         layer1_pixel,  # Background
         layer2_pixel,  # Foreground
     )
-
-
-# We have a problem; we have added six new axes to the font at this point,
-# and while the gvar table can cope with that because it gets rebuilt when
-# the font is saved, the HVAR table is not fully decompiled by fontTools,
-# so it still refers to four axes, which makes it invalid when you try
-# to save the font. Thankfully, HVAR isn't very necessary anyway, so we
-# just get rid of it.
-del font["HVAR"]
-del font["MVAR"]

--- a/scriptsLib/make.py
+++ b/scriptsLib/make.py
@@ -236,6 +236,8 @@ def makeDesignSpaceFile(dsName, dsParams, googlefonts=False):
                         googlefonts
                     ):  # For GF builds, only add default wght/slnt instances
                         continue
+                    if slnt != slnt_DEF and googlefonts:
+                        continue
 
                     template.instances.append(
                         InstanceDescriptor(

--- a/sources/stat-color.yaml
+++ b/sources/stat-color.yaml
@@ -38,8 +38,6 @@
   values:
   - name: Default
     value: 0.0
-  - name: Slanted
-    value: -8.0
 - name: Cursive
   tag: CRSV
   values:

--- a/sources/stat.yaml
+++ b/sources/stat.yaml
@@ -38,8 +38,6 @@
   values:
   - name: Default
     value: 0.0
-  - name: Slanted
-    value: -8.0
 - name: Cursive
   tag: CRSV
   values:

--- a/sources/ufo/Bitcount_Grid_Double-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Grid_Double-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Grid_Double-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Grid_Double-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Grid_Double.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Grid_Double.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Grid_Double.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Grid_Double.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Grid_Single-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Grid_Single-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WinAscent</key>

--- a/sources/ufo/Bitcount_Grid_Single-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Grid_Single-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WinAscent</key>

--- a/sources/ufo/Bitcount_Grid_Single.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Grid_Single.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WinAscent</key>

--- a/sources/ufo/Bitcount_Grid_Single.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Grid_Single.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WinAscent</key>

--- a/sources/ufo/Bitcount_Mono_Double-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Mono_Double-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Mono_Double-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Mono_Double-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Mono_Double.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Mono_Double.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Mono_Double.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Mono_Double.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Mono_Single-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Mono_Single-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Mono_Single-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Mono_Single-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Mono_Single.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Mono_Single.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Mono_Single.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Mono_Single.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Prop_Double-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Prop_Double-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Prop_Double-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Prop_Double-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Prop_Double.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Prop_Double.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Prop_Double.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Prop_Double.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Prop_Single-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Prop_Single-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Prop_Single-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Prop_Single-Italic.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Prop_Single.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Prop_Single.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>petr</string>
+    <string>robo</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>

--- a/sources/ufo/Bitcount_Prop_Single.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Prop_Single.ufo/fontinfo.plist
@@ -110,7 +110,7 @@
       <integer>62</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string>robo</string>
+    <string>TPTR</string>
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>


### PR DESCRIPTION
- Fix MVAR/HVAR error with new paintcompiler
- Skip long outline checks
- Correct vendor ID
