### PR TITLE
Bitcount Grid Simple styleMapFamilyName adjustments to solve FB fails

### DIFF
--- a/sources/ufo/Bitcount_Grid_Single-Italic.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Grid_Single-Italic.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
     <key>descender</key>
     <integer>-300</integer>
     <key>familyName</key>
-    <string>Bitcount Grid</string>
+    <string>Bitcount Grid Single</string>
     <key>guidelines</key>
     <array/>
     <key>italicAngle</key>
@@ -134,11 +134,11 @@
     <key>postscriptWeightName</key>
     <string>Regular</string>
     <key>styleMapFamilyName</key>
-    <string>BitcountGridSingle</string>
+    <string>Bitcount Grid Single</string>
     <key>styleMapStyleName</key>
-    <string>regular</string>
+    <string>italic</string>
     <key>styleName</key>
-    <string>Single Italic</string>
+    <string>Italic</string>
     <key>trademark</key>
     <string>Bitcount is a trademark of TYPETR | Buro Petr van Blokland + Claudia Mens</string>
     <key>unitsPerEm</key>

--- a/sources/ufo/Bitcount_Grid_Single.ufo/fontinfo.plist
+++ b/sources/ufo/Bitcount_Grid_Single.ufo/fontinfo.plist
@@ -134,7 +134,7 @@
     <key>postscriptWeightName</key>
     <string>Regular</string>
     <key>styleMapFamilyName</key>
-    <string>BitcountGridSingle</string>
+    <string>Bitcount Grid Single</string>
     <key>styleMapStyleName</key>
     <string>regular</string>
     <key>styleName</key>


### PR DESCRIPTION
@simoncozens, this PR is the first attempt to solve one of the Family name issues mentioned in https://github.com/petrvanblokland/TYPETR-Bitcount/issues/18#issuecomment-2276797710

I've found that the `styleMapFamilyName` did not use spaces despite the `familyName` including them. It seems that at building time, the prior was used to assign the final `name ID1` to the family.

AFAIK the first key would not be needed for these fonts, it could even be deleted. But to make a less intrusive change here, I've just added the spaces + additional changes for the italic UFO.

Please take a look at this and let me know if it is a good path to start solving all the other name-related fixes. I'll continue with the other UFO sources.

Next, we'll need to append the `Ink` particle for the colored fonts, but I haven't found the right place to do so.